### PR TITLE
Don't fail rebuild when header is removed

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -302,7 +302,7 @@ clean:
 rebuild: clean all
 
 # build dependency files
-CFLAGS += -MD
+CFLAGS += -MD -MP
 -include $(OBJECTS:.o=.d)
 
 CXXFLAGS += $(CFLAGS)


### PR DESCRIPTION
The *.d depends files for make just list the files used when building an
object file. Removing a file listed in such a dependency file causes make to
search for a way to recreate it. This usually cannot work because these files
aren't autogenerated.

The gcc option -MP can be used to generate empty rule for these files. Removing
a file in a dependency list will then execute this empty rule and continue with
the execution of the creation of the object file. This compilation process will
then automatically correct the dependency file.
